### PR TITLE
Epic #49: 書類生成システムのディレクトリ構造変更

### DIFF
--- a/10_legal-documents/.gitignore
+++ b/10_legal-documents/.gitignore
@@ -1,0 +1,33 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+venv/
+env/
+ENV/
+.venv
+pip-log.txt
+pip-delete-this-directory.txt
+
+# 生成された書類（outputsフォルダ）
+outputs/
+
+# 実際の設定ファイル（サンプルのみ保持）
+settings.yaml
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# その他
+*.log
+.env

--- a/10_legal-documents/README.md
+++ b/10_legal-documents/README.md
@@ -6,13 +6,20 @@
 
 ```
 10_legal-documents/
-├── settings.yaml           # 設定ファイル（組織情報、料金、ルール等）
+├── settings.yaml.sample   # 設定ファイルのサンプル
+├── settings.yaml          # 実際の設定ファイル（.gitignore対象）
 ├── generator.py           # 書類生成スクリプト
+├── requirements.txt       # Pythonパッケージ定義
+├── .gitignore            # Git除外設定
 ├── templates/             # Jinja2テンプレート
 │   ├── application_form.md.j2       # 申込書テンプレート
 │   ├── terms_of_service.md.j2       # 会員規約テンプレート
 │   └── postal_contract_corporate.md.j2  # 郵便サービス契約書テンプレート
-├── current/              # 生成された書類（出力先）
+├── current/              # サンプル書類（変更しない）
+│   ├── バーチャルオフィス申込書.md
+│   ├── 会員規約.md
+│   └── 郵便サービス契約書_法人.md
+├── outputs/              # 生成された書類（.gitignore対象）
 │   ├── バーチャルオフィス申込書.md
 │   ├── 会員規約.md
 │   └── 郵便サービス契約書_法人.md
@@ -75,7 +82,15 @@ exit
 
 ## 🚀 使用方法
 
-### 1. 設定の変更
+### 1. 初期設定
+
+初回実行時は、サンプルから設定ファイルをコピーします：
+
+```bash
+cp settings.yaml.sample settings.yaml
+```
+
+### 2. 設定の変更
 
 `settings.yaml`を編集して、組織情報や料金等を更新します：
 
@@ -90,7 +105,7 @@ services:
     price: 2200  # 料金変更時はここを編集
 ```
 
-### 2. 書類の生成
+### 3. 書類の生成
 
 以下のコマンドで全書類を一括生成：
 
@@ -102,11 +117,13 @@ python generator.py
 実行結果例：
 ```
 📝 書類生成を開始します...
-✅ 生成完了: current/バーチャルオフィス申込書.md
-✅ 生成完了: current/会員規約.md
-✅ 生成完了: current/郵便サービス契約書_法人.md
+✅ 生成完了: outputs/バーチャルオフィス申込書.md
+✅ 生成完了: outputs/会員規約.md
+✅ 生成完了: outputs/郵便サービス契約書_法人.md
 ✨ すべての書類が正常に生成されました。
 ```
+
+**注意**: 生成された書類は`outputs/`フォルダに保存されます。`current/`フォルダのファイルは変更されないサンプルです。
 
 ## 📋 設定項目
 
@@ -151,23 +168,25 @@ documents:
 
 ## 🔍 動作確認
 
-生成された書類は`current/`ディレクトリに保存されます。
+生成された書類は`outputs/`ディレクトリに保存されます。
 以下で内容を確認できます：
 
 ```bash
 # 申込書の確認
-cat current/バーチャルオフィス申込書.md
+cat outputs/バーチャルオフィス申込書.md
 
 # 会員規約の確認
-cat current/会員規約.md
+cat outputs/会員規約.md
 
 # 郵便サービス契約書の確認
-cat current/郵便サービス契約書_法人.md
+cat outputs/郵便サービス契約書_法人.md
 ```
 
 ## 📝 注意事項
 
-- 生成前に既存ファイルは上書きされます
+- `settings.yaml`は`.gitignore`に含まれるため、Gitには追跡されません
+- `outputs/`フォルダも`.gitignore`対象のため、生成物はGitに含まれません
+- `current/`フォルダのファイルはサンプルとして保持され、変更しないでください
 - 電話番号、メールアドレス、ウェブサイトは実際の情報に置き換えてください
 - 料金や条件を変更した場合は必ず再生成してください
 

--- a/10_legal-documents/generator.py
+++ b/10_legal-documents/generator.py
@@ -68,7 +68,9 @@ class DocumentGenerator:
             document_config: 書類設定辞書
         """
         template_path = document_config['template']
-        output_path = self.base_dir / document_config['output']
+        # outputsフォルダに出力するよう変更
+        output_filename = Path(document_config['output']).name
+        output_path = self.base_dir / 'outputs' / output_filename
         
         try:
             # テンプレートの読み込み

--- a/10_legal-documents/settings.yaml.sample
+++ b/10_legal-documents/settings.yaml.sample
@@ -1,0 +1,152 @@
+# 設定駆動型書類生成システム設定ファイル
+# このファイルから契約書類を自動生成します
+
+# ====================
+# 組織基本情報
+# ====================
+organization:
+  name: "[店名]"
+  full_name: "[店名] バーチャルオフィス"
+  postal_code: "[郵便番号]"
+  address: "[住所]"
+  tel: "[電話番号]"
+  email: "[メールアドレス]"
+  website: "[ウェブサイト]"
+  
+# ====================
+# 法務情報
+# ====================
+legal:
+  jurisdiction: 東京地方裁判所  # 管轄裁判所
+  applicable_law: 日本法  # 準拠法
+  aml_compliance: true  # 犯罪収益移転防止法対応
+  privacy_policy_required: true  # 個人情報保護方針の同意必須
+  
+# ====================
+# サービス料金（月額）
+# ====================
+services:
+  virtual_office:
+    name: バーチャルオフィスサービス
+    price: 2200
+    unit: month
+    required: true  # 必須サービス
+    description: 法人登記・住所利用サービス
+    
+  mail_receipt:
+    name: 郵便受け取りサービス
+    price: 1100
+    unit: month
+    required: false
+    description: 郵便物の受取・保管サービス
+    
+  mail_forward:
+    name: 郵便転送サービス
+    price: 3300
+    unit: month
+    required: false
+    description: 指定住所への郵便物転送サービス
+    
+# ====================
+# 契約条件
+# ====================
+terms:
+  membership:
+    min_age: 18  # 最低年齢
+    admin_fee_refundable: false  # 事務手数料返金不可
+    id_verification_required: true  # 身分証明書必須
+    
+  cancellation:
+    notice_period_months: 3  # 退会予告期間（月）
+    immediate_cancellation_fee_months: 3  # 即時退会時の料金（月分）
+    
+  mail_retention:
+    default_days: 14  # 通常保管期間（日）
+    corporate_days: 30  # 法人向け保管期間（日）
+    
+# ====================
+# 支払い方法
+# ====================
+payment_methods:
+  - id: bank_transfer
+    name: 銀行振り込み
+    name_en: Bank Transfer
+    
+  - id: direct_debit
+    name: 口座振替
+    name_en: Account Transfer
+    
+# ====================
+# 郵便物取扱いルール
+# ====================
+mail_rules:
+  # 受取不可郵便物
+  prohibited_items:
+    - 現金書留
+    - 内容証明
+    - 特別送達
+    - 本人限定受取郵便
+    - 着払いのもの
+    - 代金引換
+    - 料金不足のもの（事前相談が無い場合）
+    - 生き物
+    - 危険物
+    
+  # 特殊郵便物の取扱い
+  special_handling:
+    simple_registered: 代筆・捺印での受取可  # 簡易書留
+    specific_record: 代筆・捺印での受取可  # 特定記録
+    letter_pack_plus: 代筆・捺印での受取可  # レターパックプラス
+    
+  # 責任制限
+  liability:
+    loss_theft: 免責  # 紛失・盗難
+    delivery_delay: 免責  # 配送遅延
+    damage: 免責  # 破損
+    
+# ====================
+# 入会資格条件
+# ====================
+eligibility:
+  - 満18歳以上の個人、または法人であること
+  - 本規約の内容を承諾し、遵守すること
+  - 有効な身分証明書を提示できること
+  - 過去に当社運営施設で除名処分を受けていないこと（ただし当社が再入会を認めた場合を除く）
+  - その他、当社が入会を相応しいと判断した者
+  
+# ====================
+# 禁止事項
+# ====================
+prohibited_actions:
+  - 当社または他の会員の名誉、信用を著しく傷つける行為
+  - 当社の許可なく、当社の住所を利用して営業行為や勧誘を行うこと
+  - 法令または公序良俗に反する事業を行うこと
+  - 当社の業務を妨げる行為
+  - その他、当社が会員として不適切と判断する行為
+  
+# ====================
+# 書類メタデータ
+# ====================
+document_info:
+  version: "1.0.0"
+  established_date: "2025年8月19日"
+  last_updated: "2025年8月26日"
+  
+# ====================
+# 書類生成設定
+# ====================
+documents:
+  - id: application_form
+    title: バーチャルオフィス利用申込書
+    template: templates/application_form.md.j2
+    output: current/バーチャルオフィス申込書.md
+    
+  - id: terms_of_service
+    title: バーチャルオフィス会員規約
+    template: templates/terms_of_service.md.j2
+    output: current/会員規約.md
+    
+  - id: postal_contract_corporate
+    title: 郵便サービス契約書（法人）
+    template: templates/postal_contract_corporate.md.j2
+    output: current/郵便サービス契約書_法人.md


### PR DESCRIPTION
## 概要

@10_legal-documents/ の使い方を変更し、サンプルファイルと実際の出力を明確に分離しました。

## 変更内容

### 📁 ディレクトリ構造の変更
- `current/` - サンプル書類として保持（変更不可）
- `outputs/` - generator.pyの出力先（.gitignore対象）

### 📝 ファイル追加・修正

#### 追加ファイル
- **settings.yaml.sample** - 設定ファイルのサンプル
- **.gitignore** - outputs/とsettings.yamlを除外

#### 修正ファイル
- **generator.py** - 出力先をoutputsフォルダに変更
- **README.md** - 新しい使い方の手順に更新

## 新しい使い方

1. 初期設定
```bash
cp settings.yaml.sample settings.yaml
```

2. 設定を編集
```bash
vim settings.yaml
```

3. 書類生成（outputsフォルダに出力）
```bash
python generator.py
```

## 完了したStories
- ✅ #50 - settings.yaml.sampleを作成
- ✅ #51 - generator.pyをoutputsフォルダに出力するよう修正
- ✅ #52 - .gitignoreを作成・整備
- ✅ #53 - README.mdを更新

Epic: #49

人間レビューをお願いします。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced an outputs directory as the unified destination for generated documents.
  - Bundled a sample settings file to streamline initial configuration and customization.

- Documentation
  - Updated setup and usage to reflect the outputs-based workflow.
  - Added detailed configuration guidance and examples for creating new documents.
  - Clarified the role of the sample directory versus generated outputs.

- Chores
  - Added ignore rules for Python artifacts, environments, IDE files, logs, and OS junk to keep the workspace clean.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->