### PR TITLE
fix: 郵便サービス契約書（法人）の契約者情報フォーマット修正

### DIFF
--- a/10_legal-documents/templates/postal_contract_corporate.md.j2
+++ b/10_legal-documents/templates/postal_contract_corporate.md.j2
@@ -9,40 +9,35 @@
 ## 契約者情報
 
 {% if has_applicant_data and applicant.application_date -%}
-**契約締結日**: {{ applicant.application_date }}
-{%- else -%}
-**契約締結日**: 　　　　年　　　月　　　日
-{%- endif %}
-
+**契約締結日**: {{ applicant.application_date }}  
+{% else -%}
+**契約締結日**: 　　　　年　　　月　　　日  
+{% endif -%}
 {% if has_applicant_data and applicant.personal -%}
-**氏名**: {{ applicant.personal.name.last }} {{ applicant.personal.name.first }}
-{%- else -%}
-**氏名**: ＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿
-{%- endif %}
-
+**氏名**: {{ applicant.personal.name.last }} {{ applicant.personal.name.first }}  
+{% else -%}
+**氏名**: ＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿  
+{% endif -%}
 {% if has_applicant_data and applicant.corporate and applicant.corporate.company_name -%}
-**法人名・屋号**: {{ applicant.corporate.company_name }}
-{%- else -%}
-**法人名・屋号**: ＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿
-{%- endif %}
-
+**法人名・屋号**: {{ applicant.corporate.company_name }}  
+{% else -%}
+**法人名・屋号**: ＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿  
+{% endif -%}
 {% if has_applicant_data and applicant.address and applicant.address.current -%}
-**法人住所**: 〒{{ applicant.address.current.postal_code }} {{ applicant.address.current.prefecture }}{{ applicant.address.current.city }}{{ applicant.address.current.street }}{% if applicant.address.current.building %} {{ applicant.address.current.building }}{% endif %}
-{%- else -%}
-**法人住所**: ＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿
-{%- endif %}
-
+**法人住所**: 〒{{ applicant.address.current.postal_code }} {{ applicant.address.current.prefecture }}{{ applicant.address.current.city }}{{ applicant.address.current.street }}{% if applicant.address.current.building %} {{ applicant.address.current.building }}{% endif %}  
+{% else -%}
+**法人住所**: ＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿  
+{% endif -%}
 {% if has_applicant_data and applicant.corporate and applicant.corporate.representative -%}
-**犯罪収益移転防止法に基づく実質的支配者**: {{ applicant.corporate.representative.name }}
-{%- else -%}
-**犯罪収益移転防止法に基づく実質的支配者**: ＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿
-{%- endif %}
-
+**犯罪収益移転防止法に基づく実質的支配者**: {{ applicant.corporate.representative.name }}  
+{% else -%}
+**犯罪収益移転防止法に基づく実質的支配者**: ＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿  
+{% endif -%}
 {% if has_applicant_data and applicant.additional and applicant.additional.usage_purpose -%}
 **取引を行う目的**: {{ applicant.additional.usage_purpose }}
-{%- else -%}
+{% else -%}
 **取引を行う目的**: ＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿
-{%- endif %}
+{% endif %}
 
 ---
 


### PR DESCRIPTION
## 概要
郵便サービス契約書（法人）の契約者情報セクションで、各項目が適切に改行されずに1行に表示されていた問題を修正しました。

## 変更内容
- Jinja2テンプレートの改行制御を修正
- 各項目（契約締結日、氏名、法人名・屋号、法人住所、実質的支配者、取引目的）が個別の行に表示されるように調整
- Markdown改行記号（2スペース）を各行末に追加
- `{%-` と `-%}` タグの使い方を統一

## 修正前後
### 修正前
契約者情報が1行にまとまって表示され、読みづらい状態

### 修正後
```markdown
**契約締結日**: 2025年1月27日  
**氏名**: 渡部 健太  
**法人名・屋号**: PinkieTech株式会社  
**法人住所**: 〒152-0034 東京都目黒区緑が丘2-24-8 テックレジデンス自由が丘205A  
**犯罪収益移転防止法に基づく実質的支配者**: 渡部健太  
**取引を行う目的**: PinkieTechが北九州の方とビジネスをするための拠点として
```

## テスト結果
- ✅ 書類生成スクリプトの実行成功
- ✅ 契約者情報が正しくリスト形式で表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)