### PR TITLE
事務局使用欄と当社使用欄を設定駆動化

### DIFF
--- a/10_legal-documents/generator.py
+++ b/10_legal-documents/generator.py
@@ -130,6 +130,7 @@ class DocumentGenerator:
                 'eligibility': self.settings['eligibility'],
                 'prohibited_actions': self.settings['prohibited_actions'],
                 'document_info': self.settings['document_info'],
+                'office_use': self.settings.get('office_use', None),
                 'today': datetime.now(),
             }
             

--- a/10_legal-documents/shop-settings.yaml.sample
+++ b/10_legal-documents/shop-settings.yaml.sample
@@ -105,39 +105,22 @@ mail_rules:
     damage: 免責  # 破損
 
 # ====================
-# 事務局使用欄
+# 事務局使用欄（データ入力用）
 # ====================
 office_use:
+  # 申込書用の事務局データ
   application_form:
-    fields:
-      - label: 受付日
-        id: receipt_date
-        format: "＿＿＿＿年＿＿月＿＿日"
-      - label: 受付番号
-        id: receipt_number
-        format: "＿＿＿＿＿＿＿＿＿＿"
-      - label: 審査結果
-        id: review_result
-        format: "□承認 □否認"
-        type: checkbox
-      - label: 審査日
-        id: review_date
-        format: "＿＿＿＿年＿＿月＿＿日"
-      - label: 担当者
-        id: person_in_charge
-        format: "＿＿＿＿＿＿＿＿＿＿＿"
+    receipt_date: null  # 受付日（例: 2025年8月27日）
+    receipt_number: null  # 受付番号（例: VO-2025-0001）
+    review_result: null  # 審査結果（approved/denied）
+    review_date: null  # 審査日（例: 2025年8月28日）
+    person_in_charge: null  # 担当者名
   
+  # 郵便契約書用の当社データ
   postal_contract:
-    fields:
-      - label: 受付日
-        id: receipt_date
-        format: "＿＿＿＿年＿＿月＿＿日"
-      - label: 受付番号
-        id: receipt_number
-        format: "＿＿＿＿＿＿＿＿＿＿"
-      - label: 確認者
-        id: confirmer
-        format: "＿＿＿＿＿＿＿＿＿＿＿"
+    receipt_date: null  # 受付日（例: 2025年8月27日）
+    receipt_number: null  # 受付番号（例: PC-2025-0001）
+    confirmer: null  # 確認者名
     
 # ====================
 # 入会資格条件

--- a/10_legal-documents/shop-settings.yaml.sample
+++ b/10_legal-documents/shop-settings.yaml.sample
@@ -103,6 +103,41 @@ mail_rules:
     loss_theft: 免責  # 紛失・盗難
     delivery_delay: 免責  # 配送遅延
     damage: 免責  # 破損
+
+# ====================
+# 事務局使用欄
+# ====================
+office_use:
+  application_form:
+    fields:
+      - label: 受付日
+        id: receipt_date
+        format: "＿＿＿＿年＿＿月＿＿日"
+      - label: 受付番号
+        id: receipt_number
+        format: "＿＿＿＿＿＿＿＿＿＿"
+      - label: 審査結果
+        id: review_result
+        format: "□承認 □否認"
+        type: checkbox
+      - label: 審査日
+        id: review_date
+        format: "＿＿＿＿年＿＿月＿＿日"
+      - label: 担当者
+        id: person_in_charge
+        format: "＿＿＿＿＿＿＿＿＿＿＿"
+  
+  postal_contract:
+    fields:
+      - label: 受付日
+        id: receipt_date
+        format: "＿＿＿＿年＿＿月＿＿日"
+      - label: 受付番号
+        id: receipt_number
+        format: "＿＿＿＿＿＿＿＿＿＿"
+      - label: 確認者
+        id: confirmer
+        format: "＿＿＿＿＿＿＿＿＿＿＿"
     
 # ====================
 # 入会資格条件

--- a/10_legal-documents/templates/application_form.md.j2
+++ b/10_legal-documents/templates/application_form.md.j2
@@ -207,10 +207,12 @@
 
 ### 【事務局使用欄】
 
-{% if office_use and office_use.application_form and office_use.application_form.fields -%}
-{% for field in office_use.application_form.fields -%}
-{{ field.label }}: {{ field.format }}  
-{% endfor -%}
+{% if office_use and office_use.application_form -%}
+受付日: {% if office_use.application_form.receipt_date %}{{ office_use.application_form.receipt_date }}{% else %}＿＿＿＿年＿＿月＿＿日{% endif %}  
+受付番号: {% if office_use.application_form.receipt_number %}{{ office_use.application_form.receipt_number }}{% else %}＿＿＿＿＿＿＿＿＿＿{% endif %}  
+審査結果: {% if office_use.application_form.review_result %}{% if office_use.application_form.review_result == 'approved' %}☑承認 □否認{% elif office_use.application_form.review_result == 'denied' %}□承認 ☑否認{% else %}□承認 □否認{% endif %}{% else %}□承認 □否認{% endif %}  
+審査日: {% if office_use.application_form.review_date %}{{ office_use.application_form.review_date }}{% else %}＿＿＿＿年＿＿月＿＿日{% endif %}  
+担当者: {% if office_use.application_form.person_in_charge %}{{ office_use.application_form.person_in_charge }}{% else %}＿＿＿＿＿＿＿＿＿＿＿{% endif %}  
 {%- else -%}
 受付日: ＿＿＿＿年＿＿月＿＿日  
 受付番号: ＿＿＿＿＿＿＿＿＿＿  

--- a/10_legal-documents/templates/application_form.md.j2
+++ b/10_legal-documents/templates/application_form.md.j2
@@ -207,11 +207,17 @@
 
 ### 【事務局使用欄】
 
+{% if office_use and office_use.application_form and office_use.application_form.fields -%}
+{% for field in office_use.application_form.fields -%}
+{{ field.label }}: {{ field.format }}  
+{% endfor -%}
+{%- else -%}
 受付日: ＿＿＿＿年＿＿月＿＿日  
 受付番号: ＿＿＿＿＿＿＿＿＿＿  
 審査結果: □承認 □否認  
 審査日: ＿＿＿＿年＿＿月＿＿日  
 担当者: ＿＿＿＿＿＿＿＿＿＿＿  
+{%- endif %}  
 
 ---
 

--- a/10_legal-documents/templates/postal_contract_corporate.md.j2
+++ b/10_legal-documents/templates/postal_contract_corporate.md.j2
@@ -109,10 +109,10 @@
 
 ### 【当社使用欄】
 
-{% if office_use and office_use.postal_contract and office_use.postal_contract.fields -%}
-{% for field in office_use.postal_contract.fields -%}
-{{ field.label }}: {{ field.format }}  
-{% endfor -%}
+{% if office_use and office_use.postal_contract -%}
+受付日: {% if office_use.postal_contract.receipt_date %}{{ office_use.postal_contract.receipt_date }}{% else %}＿＿＿＿年＿＿月＿＿日{% endif %}  
+受付番号: {% if office_use.postal_contract.receipt_number %}{{ office_use.postal_contract.receipt_number }}{% else %}＿＿＿＿＿＿＿＿＿＿{% endif %}  
+確認者: {% if office_use.postal_contract.confirmer %}{{ office_use.postal_contract.confirmer }}{% else %}＿＿＿＿＿＿＿＿＿＿＿{% endif %}  
 {%- else -%}
 受付日: ＿＿＿＿年＿＿月＿＿日  
 受付番号: ＿＿＿＿＿＿＿＿＿＿  

--- a/10_legal-documents/templates/postal_contract_corporate.md.j2
+++ b/10_legal-documents/templates/postal_contract_corporate.md.j2
@@ -109,9 +109,15 @@
 
 ### 【当社使用欄】
 
+{% if office_use and office_use.postal_contract and office_use.postal_contract.fields -%}
+{% for field in office_use.postal_contract.fields -%}
+{{ field.label }}: {{ field.format }}  
+{% endfor -%}
+{%- else -%}
 受付日: ＿＿＿＿年＿＿月＿＿日  
 受付番号: ＿＿＿＿＿＿＿＿＿＿  
 確認者: ＿＿＿＿＿＿＿＿＿＿＿  
+{%- endif %}  
 
 ---
 


### PR DESCRIPTION
## 変更内容

事務局使用欄（申込書）と当社使用欄（郵便サービス契約書）を設定ファイルから管理できるようにしました。

## 主な変更点

1. **shop-settings.yaml.sample**
   - `office_use`セクションを新規追加
   - `application_form.fields`: 申込書の事務局使用欄フィールド定義
   - `postal_contract.fields`: 郵便契約書の当社使用欄フィールド定義

2. **テンプレート更新**
   - `application_form.md.j2`: 設定駆動型の事務局使用欄に対応
   - `postal_contract_corporate.md.j2`: 設定駆動型の当社使用欄に対応
   - 設定がない場合は従来のハードコード値を使用（後方互換性維持）

3. **generator.py**
   - `office_use`設定をテンプレートコンテキストに追加

## テスト方法

```bash
# 設定ファイルをコピー
cp 10_legal-documents/shop-settings.yaml.sample 10_legal-documents/settings.yaml

# 書類生成
cd 10_legal-documents
python generator.py
```

## 効果

- 事務局使用欄のフィールドを設定ファイルから自由にカスタマイズ可能
- 店舗ごとに異なる運用要件に柔軟に対応
- ハードコーディングを削減し、メンテナンス性向上

人間レビューをお願いします。

🤖 Generated with Claude Code (https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added customizable “Office Use” sections to Application Form and Postal Contract templates. Fields render dynamically from shop settings, including a checkbox review result.
  - Backward compatible: templates fall back to original placeholders when no configuration is provided.
- Documentation
  - Updated sample shop settings with office_use examples and field definitions for both forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->